### PR TITLE
Add direct rendering without CARenderer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 test: main.mm
-	MACOSX_DEPLOYMENT_TARGET=10.15 clang++ main.mm -framework Cocoa -framework OpenGL -framework QuartzCore -framework IOSurface -framework Metal -o test
+	MACOSX_DEPLOYMENT_TARGET=10.15 clang++ main.mm -std=c++17 -framework Cocoa -framework OpenGL -framework QuartzCore -framework IOSurface -framework Metal -o test

--- a/main.mm
+++ b/main.mm
@@ -60,9 +60,9 @@
 @end
 
 @interface IOSurface (SurfaceWithSizeAndDrawingHandler)
-+ (IOSurface*)ioSurfaceWithSize:(NSSize)size
-                        flipped:(BOOL)drawingHandlerShouldBeCalledWithFlippedContext
-                 drawingHandler:(void (^)(NSRect dstRect))drawingHandler;
++ (IOSurface*)ioSurfaceRGB;
++ (IOSurface*)ioSurfaceYUV;
++ (IOSurface*)ioSurfaceYUV422;
 @end
 
 @interface RunLoopThread : NSThread
@@ -175,17 +175,7 @@
       layer.anchorPoint = CGPointZero;
       layer.position = CGPointMake(100, 100);
       layer.bounds = CGRectMake(0, 0, 1920, 1080);
-      layer.contents =
-          [IOSurface ioSurfaceYUVWithSize:NSMakeSize(1920, 1080)
-                               flipped:YES
-                        drawingHandler:^(NSRect dstRect) {
-                          [[NSColor greenColor] set];
-                          NSRectFill(dstRect);
-                          [[NSColor blueColor] set];
-                          [[NSBezierPath bezierPathWithRoundedRect:NSMakeRect(20, 20, 60, 60)
-                                                           xRadius:10
-                                                           yRadius:10] fill];
-                        }];
+      layer.contents = [IOSurface ioSurfaceYUV];
       CFShow([layer.contents allAttachments]);
       layer.contentsScale = 1;
       return layer;
@@ -210,7 +200,7 @@
   layer.geometryFlipped = NO;
   [NSAnimationContext endGrouping];
   // return nil;
-  return [renderer imageByRenderingLayer:layer intoSceneOfSize:NSMakeSize(3026, 1822) withScale:1.0];
+  return [renderer imageByRenderingLayer:layer intoSceneOfSize:NSMakeSize(3026, 1822) withScale:1.0];
 }
 
 - (void)drawRect:(NSRect)rect {
@@ -558,9 +548,7 @@ static void Uint8ArrayDelete(void* info, const void* data, size_t size) { delete
 
   return [surface autorelease];
 }
-+ (IOSurface*)ioSurfaceYUVWithSize:(NSSize)size
-                        flipped:(BOOL)drawingHandlerShouldBeCalledWithFlippedContext
-                 drawingHandler:(void (^)(NSRect dstRect))drawingHandler {
++ (IOSurface*)ioSurfaceYUV {
   int width = 1920;
   int height = 1080;
   id planeInfoY = @{
@@ -581,8 +569,8 @@ static void Uint8ArrayDelete(void* info, const void* data, size_t size) { delete
   };
 
   IOSurface* surface = [[IOSurface alloc] initWithProperties:@{
-    IOSurfacePropertyKeyWidth : @(size.width),
-    IOSurfacePropertyKeyHeight : @(size.height),
+    IOSurfacePropertyKeyWidth : @(width),
+    IOSurfacePropertyKeyHeight : @(height),
     IOSurfacePropertyKeyPixelFormat : @(kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange),
     IOSurfacePropertyKeyBytesPerElement : @(4),
     IOSurfacePropertyKeyAllocSize : @(1920*1080 + 1920*1080/2),
@@ -601,14 +589,12 @@ static void Uint8ArrayDelete(void* info, const void* data, size_t size) { delete
 
   return [surface autorelease];
 }
-+ (IOSurface*)ioSurfaceYUV422WithSize:(NSSize)size
-                        flipped:(BOOL)drawingHandlerShouldBeCalledWithFlippedContext
-                 drawingHandler:(void (^)(NSRect dstRect))drawingHandler {
++ (IOSurface*)ioSurfaceYUV422 {
   int width = 1920;
   int height = 1080;
   IOSurface* surface = [[IOSurface alloc] initWithProperties:@{
-    IOSurfacePropertyKeyWidth : @(size.width),
-    IOSurfacePropertyKeyHeight : @(size.height),
+    IOSurfacePropertyKeyWidth : @(width),
+    IOSurfacePropertyKeyHeight : @(height),
     //IOSurfacePropertyKeyPixelFormat : @(kCVPixelFormatType_422YpCbCr8FullRange),
     IOSurfacePropertyKeyPixelFormat : @(kCVPixelFormatType_422YpCbCr8_yuvs),
     IOSurfacePropertyKeyBytesPerElement : @(2),
@@ -635,14 +621,12 @@ static void Uint8ArrayDelete(void* info, const void* data, size_t size) { delete
 
   return [surface autorelease];
 }
-+ (IOSurface*)ioSurfaceRGBWithSize:(NSSize)size
-                        flipped:(BOOL)drawingHandlerShouldBeCalledWithFlippedContext
-                 drawingHandler:(void (^)(NSRect dstRect))drawingHandler {
++ (IOSurface*)ioSurfaceRGB {
   int width = 1920;
   int height = 1080;
   IOSurface* surface = [[IOSurface alloc] initWithProperties:@{
-    IOSurfacePropertyKeyWidth : @(size.width),
-    IOSurfacePropertyKeyHeight : @(size.height),
+    IOSurfacePropertyKeyWidth : @(width),
+    IOSurfacePropertyKeyHeight : @(height),
     IOSurfacePropertyKeyPixelFormat : @(kCVPixelFormatType_32ARGB),
     IOSurfacePropertyKeyBytesPerElement : @(4),
     IOSurfacePropertyKeyAllocSize : @(1920*1080*4),

--- a/main.mm
+++ b/main.mm
@@ -597,6 +597,9 @@ static void Uint8ArrayDelete(void* info, const void* data, size_t size) { delete
     IOSurfacePropertyKeyPlaneWidth : @(width),
     IOSurfacePropertyKeyPlaneHeight : @(height),
     IOSurfacePropertyKeyPlaneBytesPerRow : @(width),
+    @"IOSurfacePlaneComponentBitDepths": @[@(8)],
+    @"IOSurfacePlaneComponentNames": @[@(5)],
+    @"IOSurfacePlaneComponentRanges": @[@(2)],
     IOSurfacePropertyKeyPlaneOffset : @(0),
     IOSurfacePropertyKeyPlaneSize: @(1920*1080),
     IOSurfacePropertyKeyBytesPerElement: @(1)
@@ -605,6 +608,9 @@ static void Uint8ArrayDelete(void* info, const void* data, size_t size) { delete
     IOSurfacePropertyKeyPlaneWidth : @(width/2),
     IOSurfacePropertyKeyPlaneHeight : @(height/2),
     IOSurfacePropertyKeyPlaneBytesPerRow : @(width),
+    @"IOSurfacePlaneComponentBitDepths": @[@(8), @(8)],
+    @"IOSurfacePlaneComponentNames": @[@(7), @(6)],
+    @"IOSurfacePlaneComponentRanges": @[@(2), @(2)],
     IOSurfacePropertyKeyPlaneOffset : @(1920*1080),
     IOSurfacePropertyKeyPlaneSize: @(1920*1080/2),
     IOSurfacePropertyKeyBytesPerElement: @(2)

--- a/main.mm
+++ b/main.mm
@@ -110,7 +110,7 @@
 
 @end
 
-@interface TestView : NSView {
+@interface MOZRenderToImageView : NSView {
   NSImage* img_;
   NSObject<MOZCARendererToImage>* renderer_;
   RunLoopThread* thread_;
@@ -118,7 +118,7 @@
 
 @end
 
-@implementation TestView
+@implementation MOZRenderToImageView
 
 - (id)initWithFrame:(NSRect)aFrame {
   if (self = [super initWithFrame:aFrame]) {
@@ -167,7 +167,7 @@
   [self setNeedsDisplay:YES];
 }
 
-- (CALayer*)makeScene:(int)sceneIndex scale:(CGFloat)scale {
++ (CALayer*)makeScene:(int)sceneIndex scale:(CGFloat)scale {
   switch (sceneIndex) {
     case 3: {
       CALayer* layer = [CALayer layer];
@@ -194,7 +194,7 @@
   }
   [NSAnimationContext beginGrouping];
   [CATransaction setDisableActions:YES];
-  CALayer* layer = [self makeScene:sceneIndex scale:1.0];
+  CALayer* layer = [MOZRenderToImageView makeScene:sceneIndex scale:1.0];
   self.wantsLayer = YES;
   // [[self layer] addSublayer:layer];
   layer.geometryFlipped = NO;
@@ -205,6 +205,37 @@
 
 - (void)drawRect:(NSRect)rect {
   [img_ drawInRect:[self bounds]];
+}
+
+@end
+
+@interface MOZLayerView : NSView
+
+@end
+
+@implementation MOZLayerView
+
+- (id)initWithFrame:(NSRect)aFrame {
+  self = [super initWithFrame:aFrame];
+  self.wantsLayer = YES;
+  return self;
+}
+
+- (void)dealloc {
+  [super dealloc];
+}
+
+- (BOOL)isFlipped {
+  return YES;
+}
+
+- (BOOL)wantsUpdateLayer {
+  return YES;
+}
+
+- (void)updateLayer {
+  CALayer* layer = [MOZRenderToImageView makeScene:3 scale:1.0];
+  self.layer.sublayers = @[layer];
 }
 
 @end
@@ -236,7 +267,7 @@ int main(int argc, char** argv) {
                                                    backing:NSBackingStoreBuffered
                                                      defer:NO];
 
-  NSView* view = [[TestView alloc]
+  NSView* view = [[MOZLayerView alloc]
       initWithFrame:NSMakeRect(0, 0, contentRect.size.width, contentRect.size.height)];
 
   [window setContentView:view];


### PR DESCRIPTION
It's rendering too big so there's probably a 2x scale that needs to be fixed.

This replaces the CARenderer image rendering with a different view that contains the layers directly.
It would probably be better to have a way to switch between them, or maybe we should open up two windows with different window titles.